### PR TITLE
Code cleanup, lazy schemes loading

### DIFF
--- a/lib/iuliia/iuliia.rb
+++ b/lib/iuliia/iuliia.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Iuliia
-  module_function
-
-  def translit(string, schema:)
-    Iuliia::Translit.new(string, schema).translit
+  class << self
+    def translit(string, schema:)
+      Iuliia::Translit.new(string, schema).translit
+    end
   end
 end


### PR DESCRIPTION
In most cases, people use only one chosen transliteration. This PR provides lazy loading of requested schemas on demand instead of bulk-loading to decrease memory consumption.

Also, there are some minor improvements:

- `class << self` instead of `module_function` to declare those on module level _only_ (`module_function` declares it on both eigenclass and class)
- `Iuliia::Schema#[]` method to access schemas in a more natural way
- `OpenStruct` instead of hardcoded `Struct` _and_ `JSON.parse(..., object_class: OpenStruct)` to preserve all the possible fields even if json definitions will be upgraded.