### PR TITLE
#9 add alias translit -> translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Iuliia::Schema.available_schemas
 Pick one and transliterate
 
 ```ruby
-Iuliia.translit('Юлия, съешь ещё этих мягких французских булок из Йошкар-Олы, да выпей алтайского чаю', schema: 'mvd_782')
+Iuliia.translate('Юлия, съешь ещё этих мягких французских булок из Йошкар-Олы, да выпей алтайского чаю', schema: 'mvd_782')
 
 "Yuliya, syesh' eshche etikh myagkikh frantsuzskikh bulok iz Yoshkar-Oly, da vypey altayskogo chayu"
 ```

--- a/lib/iuliia/iuliia.rb
+++ b/lib/iuliia/iuliia.rb
@@ -2,12 +2,17 @@
 
 module Iuliia
   class << self
-    # Translit cyrillic string to latin representation
+    # Translate cyrillic string to latin representation
     # @param string [String]
     # @param schema [Iuliia::Schema]
     # @return [String]
-    def translit(string, schema:)
+    def translate(string, schema:)
       Iuliia::Translit.new(string, schema).translit
+    end
+
+    def translit(string, schema:)
+      warn 'translit is deprecated, use .translate instead'
+      translate(string, schema: schema)
     end
   end
 end


### PR DESCRIPTION
"Safe alias" added with warning about method deprecation.

Example:
```
irb(main):002:0> Iuliia.translit('Юлия, съешь ещё этих мягких французских булок из Йошкар-Олы, да выпей алтайского чаю', schema: 'mvd_782')
translit is deprecated, use .translate instead
=> "Yuliya, syesh' eshche etikh myagkikh frantsuzskikh bulok iz Yoshkar-Oly, da vypey altayskogo chayu"
irb(main):003:0> Iuliia.translate('Юлия, съешь ещё этих мягких французских булок из Йошкар-Олы, да выпей алтайского чаю', schema: 'mvd_782')
=> "Yuliya, syesh' eshche etikh myagkikh frantsuzskikh bulok iz Yoshkar-Oly, da vypey altayskogo chayu"

```